### PR TITLE
Build package with C++17

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ros-noetic-gazebo-ros-control
 	pkgdesc = ROS - gazebo_ros_control.
-	pkgver = 2.9.1
+	pkgver = 2.9.2
 	pkgrel = 1
 	url = http://ros.org/wiki/gazebo_ros_control
 	arch = i686
@@ -34,8 +34,8 @@ pkgbase = ros-noetic-gazebo-ros-control
 	depends = ros-noetic-gazebo-ros
 	depends = ros-noetic-control-toolbox
 	depends = ros-noetic-transmission-interface
-	source = ros-noetic-gazebo-ros-control-2.9.1.tar.gz::https://github.com/ros-simulation/gazebo_ros_pkgs/archive/2.9.1.tar.gz
-	sha256sums = 9fac7aa1e9773aae20cfef1ec062353f91e4546ebd638e1df2e3f8b51f1e0773
+	source = ros-noetic-gazebo-ros-control-2.9.2.tar.gz::https://github.com/ros-simulation/gazebo_ros_pkgs/archive/2.9.2.tar.gz
+	sha256sums = db937f15e5bf8f804de5d8dc0b67607f8b354aecde35785b6bff2d43387abff4
 
 pkgname = ros-noetic-gazebo-ros-control
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-noetic-gazebo-ros-control
 	pkgdesc = ROS - gazebo_ros_control.
 	pkgver = 2.9.2
-	pkgrel = 1
+	pkgrel = 2
 	url = http://ros.org/wiki/gazebo_ros_control
 	arch = i686
 	arch = x86_64
@@ -35,7 +35,9 @@ pkgbase = ros-noetic-gazebo-ros-control
 	depends = ros-noetic-control-toolbox
 	depends = ros-noetic-transmission-interface
 	source = ros-noetic-gazebo-ros-control-2.9.2.tar.gz::https://github.com/ros-simulation/gazebo_ros_pkgs/archive/2.9.2.tar.gz
+	source = no_GAZEBO_CXX_FLAGS.patch
 	sha256sums = db937f15e5bf8f804de5d8dc0b67607f8b354aecde35785b6bff2d43387abff4
+	sha256sums = 3adb9bdff185e9358eda7f406d5968f2d7b18e997ccf46fa1dc0386bfb59e0bc
 
 pkgname = ros-noetic-gazebo-ros-control
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@ pkgdesc="ROS - gazebo_ros_control."
 url='http://ros.org/wiki/gazebo_ros_control'
 
 pkgname='ros-noetic-gazebo-ros-control'
-pkgver='2.9.1'
+pkgver='2.9.2'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
 pkgrel=1
 license=('BSD')
@@ -39,7 +39,7 @@ depends=(${ros_depends[@]})
 
 _dir="gazebo_ros_pkgs-${pkgver}/gazebo_ros_control"
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros-simulation/gazebo_ros_pkgs/archive/${pkgver}.tar.gz")
-sha256sums=('9fac7aa1e9773aae20cfef1ec062353f91e4546ebd638e1df2e3f8b51f1e0773')
+sha256sums=('db937f15e5bf8f804de5d8dc0b67607f8b354aecde35785b6bff2d43387abff4')
 
 build() {
   # Use ROS environment variables

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url='http://ros.org/wiki/gazebo_ros_control'
 pkgname='ros-noetic-gazebo-ros-control'
 pkgver='2.9.2'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=1
+pkgrel=2
 license=('BSD')
 
 ros_makedepends=(ros-noetic-joint-limits-interface
@@ -38,8 +38,15 @@ ros_depends=(ros-noetic-joint-limits-interface
 depends=(${ros_depends[@]})
 
 _dir="gazebo_ros_pkgs-${pkgver}/gazebo_ros_control"
-source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros-simulation/gazebo_ros_pkgs/archive/${pkgver}.tar.gz")
-sha256sums=('db937f15e5bf8f804de5d8dc0b67607f8b354aecde35785b6bff2d43387abff4')
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros-simulation/gazebo_ros_pkgs/archive/${pkgver}.tar.gz"
+        "no_GAZEBO_CXX_FLAGS.patch")
+sha256sums=('db937f15e5bf8f804de5d8dc0b67607f8b354aecde35785b6bff2d43387abff4'
+            '3adb9bdff185e9358eda7f406d5968f2d7b18e997ccf46fa1dc0386bfb59e0bc')
+
+prepare() {
+  cd "$srcdir/gazebo_ros_pkgs-$pkgver"
+  patch -p0 < "$srcdir/no_GAZEBO_CXX_FLAGS.patch"
+}
 
 build() {
   # Use ROS environment variables
@@ -52,6 +59,7 @@ build() {
 
   # Build project
   cmake ${srcdir}/${_dir} \
+        -DCMAKE_CXX_STANDARD=17 \
         -DCATKIN_BUILD_BINARY_PACKAGE=ON \
         -DCMAKE_INSTALL_PREFIX=/opt/ros/noetic \
         -DPYTHON_EXECUTABLE=/usr/bin/python \

--- a/no_GAZEBO_CXX_FLAGS.patch
+++ b/no_GAZEBO_CXX_FLAGS.patch
@@ -1,0 +1,9 @@
+--- gazebo_dev/cmake/gazebo_dev-extras.cmake	2021-04-21 19:17:36.000000000 +0100
++++ gazebo_dev/cmake/gazebo_dev-extras.cmake	2021-05-26 13:10:29.738015844 +0100
+@@ -8,6 +8,3 @@
+ set(gazebo_dev_INCLUDE_DIRS ${GAZEBO_INCLUDE_DIRS})
+ set(gazebo_dev_LIBRARY_DIRS ${GAZEBO_LIBRARY_DIRS})
+ set(gazebo_dev_LIBRARIES ${GAZEBO_LIBRARIES})
+-
+-# Append gazebo CXX_FLAGS to CMAKE_CXX_FLAGS (c++11)
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")


### PR DESCRIPTION
Fixes #1.

There seem to be two issues here:
1. The ``GAZEBO_CXX_FLAGS`` CMake variable is added to ``CXXFLAGS``, which adds ``-std=c++11``
2. The default C++ standard is < C++17

This PR fixes these issues and now the package happily builds again.